### PR TITLE
Only refresh upon receiving a pusher message

### DIFF
--- a/app/reducers/TeapotAge.js
+++ b/app/reducers/TeapotAge.js
@@ -2,6 +2,8 @@ const TeapotAge = (state = 100, action) => {
     switch (action.type) {
         case 'SET_TEAPOT_AGE':
             return action.teapotAge;
+        case 'INC_TEAPOT_AGE':
+            return state + action.minutes;
         default:
             return state;
     }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint-plugin-react": "^6.1.2",
     "material-ui": "^0.16.7",
     "mathjs": "^3.5.3",
+    "pusher-js": "^4.1.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-intl": "^2.1.5",


### PR DESCRIPTION
It might be sensible to make it fall back to periodic polling if it fails to connect to pusher, but I would rather avoid keeping the heroku instance awake indefinitely in the failure case.